### PR TITLE
refactor: common asset processor 

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -46,3 +46,14 @@ services:
     #    arguments: ['demo.elasticms.eu', '/opt/sftp_test', 'user', '/home/user/.ssh/id_rsa.pub', '/home/user/.ssh/id_rsa']
     #    tags:
     #    -  { name: ems.storage }
+
+    app.ems.cache:
+        class: EMS\CommonBundle\Storage\Adapter\FileAdapter
+        arguments: ['%env(string:STORAGE_FOLDER)%/cache']
+        tags:
+            - { name: ems_common.storage.cache_adapter }
+    app.ems.filesystem:
+        class: EMS\CommonBundle\Storage\Adapter\FileAdapter
+        arguments: ['%env(string:STORAGE_FOLDER)%']
+        tags:
+            - { name: ems_common.storage.adapter }


### PR DESCRIPTION
Moved image/asset processor logic from core to common bundle.
The core and the skeleton will use the common processor in their controllers.

- add 2 storage adapters (filesystem, cache)

Other pull requests:
- https://github.com/ems-project/website-skeleton/pull/10
- https://github.com/ems-project/EMSClientHelperBundle/pull/84
- https://github.com/ems-project/EMSCoreBundle/pull/94
- https://github.com/ems-project/EMSCommonBundle/pull/7

