### PR TITLE
fix: invalid channel templates

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -4,6 +4,7 @@ parameters:
 twig:
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
+    auto_reload: true
     globals:
       ems_hash_algo: '%env(string:EMS_HASH_ALGO)%'
     paths:


### PR DESCRIPTION
auto_reload
type: boolean default: %kernel.debug%

If true, whenever a template is rendered, Symfony checks first if its source code has changed since it was compiled. If it has changed, the template is compiled again automatically.