### PR TITLE
fix: doctrine migrations table name

### DIFF
--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -4,3 +4,9 @@ parameters:
 doctrine_migrations:
     migrations_paths:
         Application\Migrations: '%kernel.project_dir%/vendor/elasticms/core-bundle/src/Resources/DoctrineMigrations/pdo_%env(resolve:DB_DRIVER)%'
+    storage:
+        table_storage:
+            table_name: 'migration_versions'
+            version_column_name: 'version'
+            version_column_length: 191
+            executed_at_column_name: 'executed_at'


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

Doctrine migrations v3 creates a new table doctrine_migration_versions because we do not define our config correctly

More info -> https://github.com/doctrine/DoctrineMigrationsBundle/blob/3.2.x/UPGRADE.md

We should run `php bin/console doctrine:migrations:sync-metadata-storage` before executing migrations

https://github.com/ems-project/elasticms-docker/pull/96