### PR TITLE
feat: new env LOG_OUTPUT

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,9 +1,12 @@
+parameters:
+    env(LOG_OUTPUT): 'php://stdout'
+
 when@dev:
     monolog:
         handlers:
             main:
                 type: stream
-                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                path: '%env(resolve:LOG_OUTPUT)%'
                 level: debug
                 channels: ["!event", "!elastica"]
             console:

--- a/doc/Parameters.md
+++ b/doc/Parameters.md
@@ -19,6 +19,10 @@ But there is 2 more possible values, specific to elasticms:
 A secret seed.
  - Example `APP_SECRET=7b19a4a6e37b9303e4f6bca1dc6691ed`
 
+### LOG_OUTPUT
+
+Default `php://stdout` for local development you can change to `%kernel.logs_dir%/%kernel.environment%.log`
+
 ### Behind a Load Balancer or a Reverse Proxy
 
 ```dotenv


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

By default we are now logging to `php://stdout`, the env variable exists for locally development (write logs to files)