### PR TITLE
fix: APP_DISABLE_DOTENV is string from server (cast bool)

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -6,7 +6,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-$_SERVER['APP_RUNTIME_OPTIONS'] = ['disable_dotenv' => $_SERVER['APP_DISABLE_DOTENV'] ?? false];
+$_SERVER['APP_RUNTIME_OPTIONS'] = ['disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false))];
 
 return function (array $context) {
     $kernel = new Kernel($context['APP_ENV'], (bool) $context['APP_DEBUG']);

--- a/public/index.php
+++ b/public/index.php
@@ -5,7 +5,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 require_once dirname(__DIR__).'/vendor/autoload_runtime.php';
 
-$_SERVER['APP_RUNTIME_OPTIONS'] = ['disable_dotenv' => $_SERVER['APP_DISABLE_DOTENV'] ?? false];
+$_SERVER['APP_RUNTIME_OPTIONS'] = ['disable_dotenv' => ('true' === ($_SERVER['APP_DISABLE_DOTENV'] ?? false))];
 
 return function (Request $request, array $context) {
     if ($trustedProxies = $context['TRUSTED_PROXIES'] ?? false) {


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |y|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

In our docker images we export server environment variable 'APP_DISABLE_DOTENV=true'
In php this variable is a string and should be converted to true.