### PR TITLE
chore: postgres as default and with server_version

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,16 +1,18 @@
 parameters:
     env(DB_HOST): '127.0.0.1'
-    env(DB_DRIVER): 'mysql'
+    env(DB_DRIVER): 'pgsql'
     env(DB_USER): 'user'
-    env(DB_PASSWORD): 'user'
-    env(DB_PORT): '3306'
+    env(DB_PASSWORD): 'pass'
+    env(DB_PORT): '5432'
     env(DB_NAME): 'elasticms'
     env(DB_CONNECTION_TIMEOUT): 30
+    env(DB_VERSION): '11'
     env(DB_URL): '%env(string:DB_DRIVER)%://%env(string:DB_USER)%:%%env(urlencode:DB_PASSWORD)%%@%env(string:DB_HOST)%:%env(string:DB_PORT)%/%env(string:DB_NAME)%'
 
 doctrine:
     dbal:
         url: '%env(resolve:DB_URL)%'
+        server_version: '%env(string:DB_VERSION)%'
         options:
             2: '%env(int:DB_CONNECTION_TIMEOUT)%' #const PDO:ATTR_TIMEOUT = 2 , minimum value is 2 https://pracucci.com/php-pdo-pgsql-connection-timeout.html
     orm:

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -1,6 +1,3 @@
-parameters:
-    env(DB_DRIVER): 'mysql'
-
 doctrine_migrations:
     migrations_paths:
         Application\Migrations: '%kernel.project_dir%/vendor/elasticms/core-bundle/src/Resources/DoctrineMigrations/pdo_%env(resolve:DB_DRIVER)%'


### PR DESCRIPTION
|Q              |A  |
|---------------|---|
|Bug fix?       |n|
|New feature?   |n|	
|BC breaks?     |n|	
|Deprecations?  |n|	
|Fixed tickets  |n|	

No server version -> sf in prod will query database. 
Keep align with skeleton (mostly without db connection).